### PR TITLE
Do not use fallbacks for font subsets

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,6 @@ package = "netlify-plugin-a11y"
 
 [[plugins]]
 package = "netlify-plugin-subfont"
+
+  [plugins.inputs]
+    fallbacks = false


### PR DESCRIPTION
I’m not really sure what the benefits of having fallbacks are?
Maybe caching the entire font? Might undo this in the future.
