### PR TITLE
Hash assets before subfont + use subfont fallbacks

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,10 +9,10 @@ package = "netlify-plugin-a11y"
     checkPaths = ['/']
 
 [[plugins]]
-package = "netlify-plugin-subfont"
+package = "netlify-plugin-hashfiles"
 
 [[plugins]]
-package = "netlify-plugin-hashfiles"
+package = "netlify-plugin-subfont"
 
 [[plugins]]
 package = "netlify-plugin-checklinks"

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,11 +11,8 @@ package = "netlify-plugin-a11y"
 [[plugins]]
 package = "netlify-plugin-subfont"
 
-  [plugins.inputs]
-    fallbacks = false
+[[plugins]]
+package = "netlify-plugin-hashfiles"
 
 [[plugins]]
 package = "netlify-plugin-checklinks"
-
-[[plugins]]
-package = "netlify-plugin-hashfiles"

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,10 +9,10 @@ package = "netlify-plugin-a11y"
     checkPaths = ['/']
 
 [[plugins]]
+package = "netlify-plugin-checklinks"
+
+[[plugins]]
 package = "netlify-plugin-hashfiles"
 
 [[plugins]]
 package = "netlify-plugin-subfont"
-
-[[plugins]]
-package = "netlify-plugin-checklinks"


### PR DESCRIPTION
- Hash assets before subfont since subfont already hashes fonts
    - The previous config was creating 404s
- Use fallbacks for subfonts (undoing #125)
    - I decided this was better
